### PR TITLE
Refactors, Fixes, and Updates

### DIFF
--- a/6.8.9-10_q8/Dockerfile
+++ b/6.8.9-10_q8/Dockerfile
@@ -1,76 +1,13 @@
-# Start with Debian Wheezy
-FROM debian:wheezy
-
-MAINTAINER Jamin Kortegard <jamink919@gmail.com>
-
-# Get basic utils
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        apt-utils \
-        bzip2 \
-        ca-certificates \
-        curl \
-        wget \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install dependencies for ImageMagick.
-RUN apt-get -y update && apt-get install -y --no-install-recommends \
-        dcraw \
-        libfreetype6 \
-        libfreetype6-dev \
-        libgif4 \
-        libgif-dev \
-        libjasper1 \
-        libjasper-dev \
-        libjpeg8 \
-        libjpeg8-dev \
-        liblcms2-2 \
-        liblcms2-dev \
-        libpng12-0 \
-        libpng12-dev \
-        libtiff5 \
-        libtiff5-dev \
-        libwmf0.2-7 \
-        libwmf-dev \
-        libxml2 \
-        libxml2-dev \
-        zlib1g \
-        zlib1g-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-
-# Create temp dir for installations
-WORKDIR /tmp/install
-
-# Compilers for Ghostscript and ImageMagick.
-# This will be wasted layer space afterwards. How to optimize?
-RUN apt-get -y update && apt-get install -y --no-install-recommends \
-        autoconf \
-        automake \
-        build-essential \
-        libx11-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install specific Ghostscript 9.15
-ENV GS_VER 9.15
-
-RUN curl -L -O http://downloads.ghostscript.com/public/ghostscript-${GS_VER}.tar.gz \
-    && tar -xzf ghostscript-${GS_VER}.tar.gz\
-    && cd ghostscript-${GS_VER} \
-    && ./configure \
-    && make \
-    && make install \
-    && make clean \
-    && ldconfig \
-    && cd /tmp/install \
-    && rm -rf ghostscript-${GS_VER}*
+# Start with magickdeps
+FROM magickdeps
 
 # Install ImageMagick with PerlMagick module
 ENV MAGICK_VER 6.8.9-10
 
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
     libperl-dev \
-    && curl -L -O http://www.imagemagick.org/download/releases/ImageMagick-${MAGICK_VER}.tar.bz2 \
-    && tar -xjf ImageMagick-${MAGICK_VER}.tar.bz2 \
+    && curl -L -O http://www.imagemagick.org/download/releases/ImageMagick-${MAGICK_VER}.tar.xz \
+    && tar -xf ImageMagick-${MAGICK_VER}.tar.xz \
     && cd ImageMagick-${MAGICK_VER} \
     && ./configure --enable-shared --with-gslib --with-wmf --without-x --with-xml \
         --with-freetype --with-fontconfig --with-quantum-depth=8 --with-perl=/usr/bin/perl \

--- a/6.8.9-10_q8/README.md
+++ b/6.8.9-10_q8/README.md
@@ -4,7 +4,7 @@
 * `latest` [_(Dockerfile)_](https://github.com/AllYourBase/docker-imagemagick/blob/master/6.8.9-10_q8/Dockerfile)
 
 ## Description
-ImageMagick 6.8.9-10 built [from source](http://www.imagemagick.org/script/install-source.php#unix) with quantum depth 8 for faster processing. This build based on [`debian:wheezy` Docker image](https://registry.hub.docker.com/u/library/debian/). Includes Ghostscript 9.15 delegate for PostScript and PDF processing. Includes PerlMagick module installed onto Debian system Perl v 5.14.2.
+ImageMagick 6.8.9-10 built [from source](http://www.imagemagick.org/script/install-source.php#unix) with quantum depth 8 for faster processing. This build based on an intermediate "magickdeps" image, which in turn is based on a [`debian:jessie` Docker image](https://registry.hub.docker.com/u/library/debian/). Includes Ghostscript 9.15 delegate for PostScript and PDF processing. Includes PerlMagick module installed onto Debian system Perl v 5.14.2.
 
 ## Usage
 ````

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# magickdeps
+## Description
+Common dependencies for building ImageMagick and GraphicsMagick

--- a/magickdeps/Dockerfile
+++ b/magickdeps/Dockerfile
@@ -1,0 +1,62 @@
+# Start with Debian Jessie
+FROM debian:jessie
+
+MAINTAINER Jamin Kortegard <jamink919@gmail.com>
+
+# Get basic utils
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        apt-utils \
+        bzip2 \
+        ca-certificates \
+        curl \
+        wget
+
+# Install dependencies for ImageMagick/GraphicsMagick.
+RUN apt-get install -y --no-install-recommends \
+        dcraw \
+        libfreetype6 \
+        libfreetype6-dev \
+        libgif4 \
+        libgif-dev \
+        libjasper1 \
+        libjasper-dev \
+        libturbojpeg1 \
+        libturbojpeg1-dev \
+        liblcms2-2 \
+        liblcms2-dev \
+        libpng12-0 \
+        libpng12-dev \
+        libtiff5 \
+        libtiff5-dev \
+        libwmf0.2-7 \
+        libwmf-dev \
+        libxml2 \
+        libxml2-dev \
+        zlib1g \
+        zlib1g-dev
+
+
+# Create temp dir for installations
+WORKDIR /tmp/install
+
+# Compilers for Ghostscript and GraphicsMagick/ImageMagick.
+# This will be wasted layer space afterwards. How to optimize?
+RUN apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        libx11-dev
+
+# Install specific Ghostscript 9.15
+ENV GS_VER 9.15
+
+RUN curl -L -O http://downloads.ghostscript.com/public/ghostscript-${GS_VER}.tar.gz \
+    && tar -xzf ghostscript-${GS_VER}.tar.gz\
+    && cd ghostscript-${GS_VER} \
+    && ./configure \
+    && make \
+    && make install \
+    && make clean \
+    && ldconfig
+
+RUN rm -rf /tmp/install && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR does three things:
- Refactors dependencies common to ImageMagick and GraphicsMagick into their own 'magickdeps' image
- Updates the base image to debian:jessie and libjpeg to libjpeg-turbo
- Fixes the source download location for ImageMagick (Fixes #1)

Since I can't push to your dockerhub account, the ImageMagick Dockerfile is based on a local 'magickdeps' right now, but if you want to upload magickdeps then you can change the reference there, obviously.
